### PR TITLE
Add advanced request matching option to WebValve.register

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,32 @@ You will have to restart your application after making this change
 because service faking is an initialization time concern and not a
 runtime concern.
 
+### Advanced request matching
+
+You can also use the `request_matcher` option when registering a service to specify
+additional request matching criteria. This is particularly useful when
+you need to mock requests based on the request body or other parameters,
+not just the URL.
+
+```ruby
+# config/webvalve.rb
+WebValve.register(
+  "FakeBank",
+  request_matcher: {
+    body: WebMock::Matchers::HashIncludingMatcher.new(action: 'limit_order')
+  }
+)
+```
+
+In this example, the FakeBank service will only be used for requests that
+match request body that includes the key `action` with the value `limit_order`.
+
+The `request_matcher` option accepts the same parameters as WebMock's
+`with` method, including:
+- `:body`
+- `:headers`
+- `:query`
+
 ## Configuring fakes in tests
 
 In order to get WebValve fake services working properly in tests, you

--- a/lib/webvalve/fake_service_config.rb
+++ b/lib/webvalve/fake_service_config.rb
@@ -1,10 +1,11 @@
 module WebValve
   class FakeServiceConfig
-    attr_reader :service_class_name
+    attr_reader :service_class_name, :request_matcher
 
-    def initialize(service_class_name:, url: nil)
+    def initialize(service_class_name:, url: nil, request_matcher: nil)
       @service_class_name = service_class_name
       @custom_service_url = url
+      @request_matcher = request_matcher
     end
 
     def explicitly_enabled?

--- a/spec/webvalve/fake_service_config_spec.rb
+++ b/spec/webvalve/fake_service_config_spec.rb
@@ -19,6 +19,19 @@ RSpec.describe WebValve::FakeServiceConfig do
 
   subject { described_class.new service_class_name: fake_service.name }
 
+  describe 'initialization' do
+    it 'accepts a custom url' do
+      config = described_class.new(service_class_name: fake_service.name, url: 'http://custom.dev')
+      expect(config.full_url).to eq 'http://custom.dev'
+    end
+
+    it 'accepts request_matcher' do
+      request_matcher = { foo: 'bar' }
+      config = described_class.new(service_class_name: fake_service.name, request_matcher: request_matcher)
+      expect(config.request_matcher).to eq request_matcher
+    end
+  end
+
   describe '.explicitly_enabled?' do
     it 'returns false when DUMMY_ENABLED is unset' do
       expect(subject.explicitly_enabled?).to eq false
@@ -110,6 +123,33 @@ RSpec.describe WebValve::FakeServiceConfig do
       with_env 'DUMMY_API_URL' => 'http://zombo.com/welcome/' do
         expect(subject.path_prefix).to eq '/welcome' # Ignores trailing '/'
       end
+    end
+  end
+
+  describe '.full_url' do
+    it 'returns the custom service url when provided' do
+      with_env 'DUMMY_API_URL' => 'http://default.dev' do
+        config = described_class.new(service_class_name: fake_service.name, url: 'http://custom.dev')
+        expect(config.full_url).to eq 'http://custom.dev'
+      end
+    end
+
+    it 'returns the default service url when custom url is not provided' do
+      with_env 'DUMMY_API_URL' => 'http://default.dev' do
+        expect(subject.full_url).to eq 'http://default.dev'
+      end
+    end
+  end
+
+  describe '.request_matcher' do
+    it 'returns the provided request params' do
+      params = { foo: 'bar' }
+      config = described_class.new(service_class_name: fake_service.name, request_matcher: params)
+      expect(config.request_matcher).to eq params
+    end
+
+    it 'returns nil when no request params are provided' do
+      expect(subject.request_matcher).to be_nil
     end
   end
 end

--- a/spec/webvalve/manager_spec.rb
+++ b/spec/webvalve/manager_spec.rb
@@ -152,6 +152,36 @@ RSpec.describe WebValve::Manager do
         end
       end
 
+      it 'raises with duplicate stubbed urls with same `request_matcher` parameter' do
+        service = class_double(WebValve::FakeService, name: 'FakeSomething')
+        other_service = class_double(WebValve::FakeService, name: 'FakeOtherThing')
+
+        subject.register service.name, url: "http://something.dev", request_matcher: { body: 'foo' }
+        subject.register other_service.name, url: "http://something.dev", request_matcher: { body: 'foo' }
+
+        expect { subject.setup }.to raise_error('Invalid config for FakeOtherThing. Already stubbed url http://something.dev with {:body=>"foo"}')
+      end
+
+      it 'raises with duplicate stubbed urls when `request_matcher` parameter is nil' do
+        service = class_double(WebValve::FakeService, name: 'FakeSomething')
+        other_service = class_double(WebValve::FakeService, name: 'FakeOtherThing')
+
+        subject.register service.name, url: "http://something.dev"
+        subject.register other_service.name, url: "http://something.dev", request_matcher: { body: 'foo' }
+
+        expect { subject.setup }.to raise_error('Invalid config for FakeOtherThing. Already stubbed url http://something.dev')
+      end
+
+      it 'does not raise error with duplicate stubbed urls but different `request_matcher` parameters' do
+        service = class_double(WebValve::FakeService, name: 'FakeSomething')
+        other_service = class_double(WebValve::FakeService, name: 'FakeOtherThing')
+
+        subject.register service.name, url: "http://something.dev", request_matcher: { body: 'bar' }
+        subject.register other_service.name, url: "http://something.dev", request_matcher: { body: 'foo' }
+
+        expect { subject.setup }.not_to raise_error
+      end
+
       it 'does not raise with different HTTP auth patterns' do
         disabled_service = class_double(WebValve::FakeService, name: 'FakeSomething')
         other_disabled_service = class_double(WebValve::FakeService, name: 'FakeOtherThing')


### PR DESCRIPTION
### Problem
Currently, WebValve allows mocking of services based on URL matching. However, some APIs use a single URL for multiple endpoints, distinguishing between them using parameters in the request body (e.g., a `methodName` parameter for some kind of RPC). In these cases, users may want to mock only a subset of the API calls, which is not possible with the current implementation.

### Solution
This PR introduces a new `request_matcher` option for `WebValve.register`. This option allows users to specify additional request matching criteria, including body content, headers, and query parameters. This enhancement leverages WebMock's request matching capabilities, giving users more fine-grained control over which requests are mocked.

### Example Usage

```ruby
WebValve.register "FakeBank", request_matcher: { 
  body: WebMock::Matchers::HashIncludingMatcher.new(action: 'limit_order')
}
```

In this example, only requests to the `FakeBank` service with a body containing `action: 'limit_order'` will be mocked. This allows users to selectively mock specific API calls even when they share the same base URL.

### Backwards Compatibility
This change is fully backwards compatible. Existing usage of `WebValve.register` without the `with` option will continue to work as before.